### PR TITLE
fix callbacks, add image logging

### DIFF
--- a/libs/training.py
+++ b/libs/training.py
@@ -43,9 +43,10 @@ def train_model(dataset):
 
     data = datasets.load_dataset(dataset, size, bs)
     encoder_model = models.resnet18
-    learn = unet_learner(data, encoder_model, path='models', metrics=metrics, wd=wd, bottle=True, pretrained=pretrained, callback_fns=WandbCallback)
+    learn = unet_learner(data, encoder_model, path='models', metrics=metrics, wd=wd, bottle=True, pretrained=pretrained)
 
     callbacks = [
+        WandbCallback(learn, log=None, input_type="images"),
         MyCSVLogger(learn, filename='baseline_model'),
         ExportCallback(learn, "baseline_model", monitor='f_beta'),
         MySaveModelCallback(learn, every='epoch', monitor='f_beta')

--- a/libs/util.py
+++ b/libs/util.py
@@ -1,5 +1,6 @@
 from typing import Any
-from fastai.callbacks import CSVLogger, Callback, SaveModelCallback, TrackerCallback
+from fastai.callbacks import CSVLogger, SaveModelCallback, TrackerCallback
+from fastai.callback import Callback
 from fastai.metrics import add_metrics
 from fastai.torch_core import dataclass, torch, Tensor, Optional, warn
 from fastai.basic_train import Learner
@@ -22,6 +23,7 @@ class ExportCallback(TrackerCallback):
             self.best = current
             self.learn.export(self.model_path)
 
+# TODO: does this delete some other path or just overwrite?
 class MySaveModelCallback(SaveModelCallback):
     """Saves the model after each epoch to potentially resume training.
 
@@ -48,6 +50,7 @@ class MyCSVLogger(CSVLogger):
 
     def on_train_begin(self, **kwargs):
         if self.path.exists():
+            # TODO: does this open a file named "a"...?
             self.file = self.path.open('a')
         else:
             super().on_train_begin(**kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-numpy==1.17.1
-torch==1.1.0
+fastai
 opencv_python==3.4.3.18
+numpy==1.17.1
+sklearn
+torch
 typing==3.6.6
-fastai==1.0.54
+wandb


### PR DESCRIPTION
* combined callbacks for consistency
* WandbCallback(input_type="images") logs nice visualizations in the media tab at the very bottom of the run/project overview page
![Screen Shot 2019-10-01 at 7 20 25 PM](https://user-images.githubusercontent.com/45573465/66013580-9a77cc80-e480-11e9-80eb-c53429aa0ec3.png)
* in libs/util, changed callback import to allow us to use all the latest versions of torch/torchvision/fastai
* in libs/util, added clarification questions as TODOs (happy to file issues instead)
* alphabetized requirements, added missing ones, removed versions where I think we should/can safely pull the latest now--let me know if this ends up causing other issues
* tried to get rid of too many "gradient" columns in table with "log=None" arg to WandbCallback, seems insufficient--will keep working on that