### PR TITLE
ResNet18 import fixation

### DIFF
--- a/libs/models_keras.py
+++ b/libs/models_keras.py
@@ -40,8 +40,7 @@ def build_unet(size=300, basef=64, maxf=512, encoder='resnet50', pretrained=True
 
 def make_encoder(input, name='resnet50', pretrained=True):
     if name == 'resnet18':
-        from classification_models.keras import Classifiers
-        ResNet18, _ = Classifiers.get('resnet18')
+        from keras.applications.resnet import ResNet18
         model = ResNet18(
             weights='imagenet' if pretrained else None,
             input_tensor=input,


### PR DESCRIPTION
Referring to the [`models_keras.py`](https://github.com/dronedeploy/dd-ml-segmentation-benchmark/blob/master/libs/models_keras.py) script, `ResNet18` is being imported as `from classification_models.keras import Classifiers` but I was unable to find the `classification_models` module in the first place. 

I swapped it with:

```python
from keras.applications.resnet import ResNet18
model = ResNet18(
            weights='imagenet' if pretrained else None,
            input_tensor=input,
            include_top=False)
```